### PR TITLE
Say hello

### DIFF
--- a/app/components/Navbar.jsx
+++ b/app/components/Navbar.jsx
@@ -4,7 +4,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { Sheet, SheetContent, SheetTrigger } from "./ui/sheet"
 import { ModeToggle } from "./ThemeToggle"
 import { Avatar, AvatarFallback } from "./ui/avatar"
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import { useTranslation } from 'react-i18next'
 import { LangToggle } from './LangToggle'
 import { track } from '../lib/utils'
@@ -109,7 +109,7 @@ function OfferBar() {
 }
 
 function DesktopOrderBar({ isOpen, eta }) {
-  if (typeof window !== 'undefined' && window.innerWidth < 1024) return null
+  const { t } = useTranslation('ui')
   return (
     <div className="hidden lg:block border-b bg-background">
       <div className="container mx-auto h-10 px-4 flex items-center justify-between text-sm">
@@ -119,7 +119,7 @@ function DesktopOrderBar({ isOpen, eta }) {
         <div className="flex items-center gap-3">
           <div className="text-muted-foreground hidden md:block">No sign-up needed</div>
           <NavLink to="/menu" className="underline">Browse menu</NavLink>
-          <Button onClick={() => track('click_order_now_topbar')}>Order Now</Button>
+          <Button onClick={() => track('click_order_now_topbar')}>{t('nav.orderNow')}</Button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Remove unused `useRef` import and localize the "Order Now" button in `Navbar.jsx`.

The client-side `window.innerWidth` check was removed from `DesktopOrderBar` to prevent potential hydration mismatches and flickering, as CSS already handles its visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-8be5ad7c-5a84-4682-ba23-e6f4a3ad44be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8be5ad7c-5a84-4682-ba23-e6f4a3ad44be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

