### PR TITLE
Say hello

### DIFF
--- a/app/entry.client.jsx
+++ b/app/entry.client.jsx
@@ -11,18 +11,17 @@ import { rtlLngs } from './lib/i18n.js';
  */
 startTransition(async () => {
   try {
-    // Get language from server context (SSR) or detect on client
-    const serverLang = window.__REACT_ROUTER_DATA__?.context?.lng;
+    // Get language from various sources (React Router loader data is handled in root.jsx)
     const urlLang = new URLSearchParams(window.location.search).get('lng');
     const storedLang = localStorage.getItem('lng');
     const cookieLang = document.cookie.split('; ').find(row => row.startsWith('i18next='))?.split('=')[1];
     
-    // Language priority: URL > Server > Cookie > localStorage > Default
-    const lng = urlLang || serverLang || cookieLang || storedLang || 'en';
+    // Language priority: URL > Cookie > localStorage > Default
+    // Note: Server language is accessed through React Router loader in root.jsx
+    const lng = urlLang || cookieLang || storedLang || 'en';
     
     console.log('🌍 Client language detection:', {
       url: urlLang,
-      server: serverLang,
       cookie: cookieLang,
       stored: storedLang,
       final: lng


### PR DESCRIPTION
Remove incorrect server language access from client-side initialization to align with React Router v7's loader system.

The previous approach of accessing `window.__REACT_ROUTER_DATA__?.context?.lng` for server-rendered language is not supported in React Router v7, causing `serverLang` to be `undefined`. This change ensures the client-side `entry.client.jsx` focuses on client-specific language detection (URL, cookie, localStorage), while the server language is correctly handled and passed through React Router's loader system in `root.jsx`.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a95fa05-6212-49f0-b1fd-32fd6397a225">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0a95fa05-6212-49f0-b1fd-32fd6397a225">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

