### PR TITLE
Say hello

### DIFF
--- a/server/locales/en/home.json
+++ b/server/locales/en/home.json
@@ -81,12 +81,15 @@
   },
   "popular": {
     "heading": "Popular This Week",
-    "seeMenu": "See Full Menu",
+    "seeMenu": "See Full Menu", 
     "coming": "Coming Soon",
     "chefSpecial": "Chef Special {{num}}",
     "notify": "Notify Me",
     "add": "Add to Cart",
-    "rating": "4.9/5 from 2,400+ locals"
+    "rating": "4.9/5 from 2,400+ locals",
+    "numberOne": "#1",
+    "trending": "Trending",
+    "unavailable": "Unavailable"
   },
   "loyalty": {
     "heading": "Loyalty & Rewards",

--- a/server/locales/en/menu.json
+++ b/server/locales/en/menu.json
@@ -1,0 +1,45 @@
+{
+  "categories": {
+    "tacos": "Tacos",
+    "bowls": "Bowls", 
+    "drinks": "Drinks",
+    "sides": "Sides",
+    "desserts": "Desserts",
+    "specials": "Chef Specials"
+  },
+  "filters": {
+    "all": "All Items",
+    "vegetarian": "Vegetarian",
+    "vegan": "Vegan", 
+    "glutenFree": "Gluten Free",
+    "spicy": "Spicy",
+    "popular": "Popular",
+    "new": "New"
+  },
+  "sort": {
+    "popularity": "Most Popular",
+    "price": "Price",
+    "name": "Name",
+    "rating": "Rating"
+  },
+  "actions": {
+    "addToCart": "Add to Cart",
+    "customize": "Customize",
+    "viewDetails": "View Details",
+    "outOfStock": "Out of Stock",
+    "comingSoon": "Coming Soon"
+  },
+  "dietary": {
+    "vegetarian": "Vegetarian",
+    "vegan": "Vegan",
+    "glutenFree": "Gluten Free",
+    "dairyFree": "Dairy Free",
+    "nutFree": "Nut Free"
+  },
+  "prep": {
+    "mild": "Mild",
+    "medium": "Medium", 
+    "hot": "Hot",
+    "extraHot": "Extra Hot"
+  }
+}

--- a/server/locales/en/ui.json
+++ b/server/locales/en/ui.json
@@ -1,0 +1,56 @@
+{
+  "navigation": {
+    "home": "Home",
+    "menu": "Menu", 
+    "reservations": "Reservations",
+    "catering": "Catering",
+    "about": "About",
+    "contact": "Contact",
+    "account": "Account",
+    "orders": "Orders",
+    "settings": "Settings"
+  },
+  "topbar": {
+    "open": "Open now",
+    "closed": "Closed",
+    "eta": "{{mins}} min delivery",
+    "noSignup": "No signup required",
+    "browse": "Browse menu"
+  },
+  "offer": {
+    "freeDelivery": "Free delivery on orders over $25"
+  },
+  "buttons": {
+    "orderNow": "Order Now",
+    "reserve": "Reserve Table", 
+    "addToCart": "Add to Cart",
+    "viewCart": "View Cart",
+    "checkout": "Checkout",
+    "login": "Login",
+    "signup": "Sign Up",
+    "logout": "Logout"
+  },
+  "common": {
+    "loading": "Loading...",
+    "error": "Something went wrong",
+    "retry": "Try again",
+    "close": "Close",
+    "save": "Save",
+    "cancel": "Cancel",
+    "submit": "Submit",
+    "next": "Next",
+    "previous": "Previous",
+    "search": "Search",
+    "filter": "Filter",
+    "sort": "Sort"
+  },
+  "cart": {
+    "empty": "Your cart is empty",
+    "total": "Total",
+    "subtotal": "Subtotal", 
+    "tax": "Tax",
+    "delivery": "Delivery",
+    "itemCount": "{{count}} item",
+    "itemCount_plural": "{{count}} items"
+  }
+}

--- a/server/locales/es/menu.json
+++ b/server/locales/es/menu.json
@@ -1,0 +1,45 @@
+{
+  "categories": {
+    "tacos": "Tacos",
+    "bowls": "Bowls", 
+    "drinks": "Bebidas",
+    "sides": "Acompañamientos",
+    "desserts": "Postres",
+    "specials": "Especialidades del Chef"
+  },
+  "filters": {
+    "all": "Todos los Artículos",
+    "vegetarian": "Vegetariano",
+    "vegan": "Vegano", 
+    "glutenFree": "Sin Gluten",
+    "spicy": "Picante",
+    "popular": "Popular",
+    "new": "Nuevo"
+  },
+  "sort": {
+    "popularity": "Más Popular",
+    "price": "Precio",
+    "name": "Nombre",
+    "rating": "Calificación"
+  },
+  "actions": {
+    "addToCart": "Agregar al Carrito",
+    "customize": "Personalizar",
+    "viewDetails": "Ver Detalles",
+    "outOfStock": "Agotado",
+    "comingSoon": "Próximamente"
+  },
+  "dietary": {
+    "vegetarian": "Vegetariano",
+    "vegan": "Vegano",
+    "glutenFree": "Sin Gluten",
+    "dairyFree": "Sin Lácteos",
+    "nutFree": "Sin Nueces"
+  },
+  "prep": {
+    "mild": "Suave",
+    "medium": "Medio", 
+    "hot": "Picante",
+    "extraHot": "Extra Picante"
+  }
+}

--- a/server/locales/es/ui.json
+++ b/server/locales/es/ui.json
@@ -1,0 +1,56 @@
+{
+  "navigation": {
+    "home": "Inicio",
+    "menu": "Menú", 
+    "reservations": "Reservaciones",
+    "catering": "Catering",
+    "about": "Acerca de",
+    "contact": "Contacto",
+    "account": "Cuenta",
+    "orders": "Pedidos",
+    "settings": "Configuración"
+  },
+  "topbar": {
+    "open": "Abierto ahora",
+    "closed": "Cerrado",
+    "eta": "{{mins}} min entrega",
+    "noSignup": "No requiere registro",
+    "browse": "Ver menú"
+  },
+  "offer": {
+    "freeDelivery": "Entrega gratis en pedidos sobre $25"
+  },
+  "buttons": {
+    "orderNow": "Ordenar Ahora",
+    "reserve": "Reservar Mesa", 
+    "addToCart": "Agregar al Carrito",
+    "viewCart": "Ver Carrito",
+    "checkout": "Pagar",
+    "login": "Iniciar Sesión",
+    "signup": "Registrarse",
+    "logout": "Cerrar Sesión"
+  },
+  "common": {
+    "loading": "Cargando...",
+    "error": "Algo salió mal",
+    "retry": "Intentar de nuevo",
+    "close": "Cerrar",
+    "save": "Guardar",
+    "cancel": "Cancelar",
+    "submit": "Enviar",
+    "next": "Siguiente",
+    "previous": "Anterior",
+    "search": "Buscar",
+    "filter": "Filtrar",
+    "sort": "Ordenar"
+  },
+  "cart": {
+    "empty": "Tu carrito está vacío",
+    "total": "Total",
+    "subtotal": "Subtotal", 
+    "tax": "Impuesto",
+    "delivery": "Entrega",
+    "itemCount": "{{count}} artículo",
+    "itemCount_plural": "{{count}} artículos"
+  }
+}

--- a/server/locales/fr/menu.json
+++ b/server/locales/fr/menu.json
@@ -1,0 +1,45 @@
+{
+  "categories": {
+    "tacos": "Tacos",
+    "bowls": "Bols", 
+    "drinks": "Boissons",
+    "sides": "Accompagnements",
+    "desserts": "Desserts",
+    "specials": "Spécialités du Chef"
+  },
+  "filters": {
+    "all": "Tous les Articles",
+    "vegetarian": "Végétarien",
+    "vegan": "Végétalien", 
+    "glutenFree": "Sans Gluten",
+    "spicy": "Épicé",
+    "popular": "Populaire",
+    "new": "Nouveau"
+  },
+  "sort": {
+    "popularity": "Plus Populaire",
+    "price": "Prix",
+    "name": "Nom",
+    "rating": "Note"
+  },
+  "actions": {
+    "addToCart": "Ajouter au Panier",
+    "customize": "Personnaliser",
+    "viewDetails": "Voir Détails",
+    "outOfStock": "Épuisé",
+    "comingSoon": "Bientôt Disponible"
+  },
+  "dietary": {
+    "vegetarian": "Végétarien",
+    "vegan": "Végétalien",
+    "glutenFree": "Sans Gluten",
+    "dairyFree": "Sans Lactose",
+    "nutFree": "Sans Noix"
+  },
+  "prep": {
+    "mild": "Doux",
+    "medium": "Moyen", 
+    "hot": "Épicé",
+    "extraHot": "Très Épicé"
+  }
+}


### PR DESCRIPTION
Add missing translation keys and create new `menu.json` and `ui.json` files for English, Spanish, and French to fix reported i18n display issues on the homepage, menu filters, and navbar.

Specifically, `popular.numberOne` was missing from `home.json`, `filters.vegetarian` required a new `menu` namespace, and `offer.freeDelivery` was missing from a new `ui` namespace. This PR introduces these keys and namespaces, along with initial Spanish and French translations.

---
<a href="https://cursor.com/background-agent?bcId=bc-b30bc031-2510-4de7-83f7-c5fc8514deaf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b30bc031-2510-4de7-83f7-c5fc8514deaf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

