### PR TITLE
Investigate translation mismatch and hydration errors

### DIFF
--- a/app/components/home/Offers.jsx
+++ b/app/components/home/Offers.jsx
@@ -1,12 +1,14 @@
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 export default function Offers({ offers, t, cmsOffers = [], heading, badge }) {
   const list = (cmsOffers && cmsOffers.length) ? cmsOffers : offers;
   const primary = list?.[0];
   const expiry = useMemo(() => (primary?.expiresAt ? new Date(primary.expiresAt).getTime() : Date.now() + 1000 * 60 * 60 * 24), [primary?.expiresAt]);
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => { setHydrated(true); }, []);
   if (!primary) {
     return (
       <Card>
@@ -36,7 +38,7 @@ export default function Offers({ offers, t, cmsOffers = [], heading, badge }) {
             <div>
               <div className="text-sm text-muted-foreground">{primary.bundleName || t?.('home:offers.bundle') || 'Taco Tuesday Bundle'}</div>
               <div className="text-xl font-semibold">{primary.title || t?.('home:offers.deal') || '2 tacos + drink — $9.99'}</div>
-              <div className="text-xs text-muted-foreground">{t?.('home:offers.endsIn') || 'Ends in'} <span data-offer-id={primary.id}>{formatCountdown(expiry)}</span></div>
+              <div className="text-xs text-muted-foreground">{t?.('home:offers.endsIn') || 'Ends in'} <span data-offer-id={primary.id}>{hydrated ? formatCountdown(expiry) : '--:--:--'}</span></div>
             </div>
             <div className="flex gap-2">
               <Button>{t?.('home:offers.orderBundle') || 'Order bundle'}</Button>

--- a/app/components/home/Testimonials.jsx
+++ b/app/components/home/Testimonials.jsx
@@ -37,7 +37,7 @@ export default function Testimonials({ testimonials = [] }) {
                       <Star key={i} className={`size-3 ${i < Number(tst.rating || 5) ? 'fill-current' : ''}`} />
                     ))}
                   </div>
-                  {tst.date && <div className="text-xs text-muted-foreground">{new Date(tst.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}</div>}
+                  {tst.date && <div className="text-xs text-muted-foreground">{new Date(tst.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC' })}</div>}
                 </div>
                 <div className="text-sm text-muted-foreground mt-1">
                   {tst.content || fallbacks[idx % fallbacks.length]} <button className="underline text-xs">{t('testimonials.readMore')}</button>

--- a/app/entry.client.jsx
+++ b/app/entry.client.jsx
@@ -4,12 +4,14 @@ import { HydratedRouter } from "react-router/dom";
 import { I18nextProvider } from 'react-i18next';
 import { initI18n, rtlLngs } from './lib/i18n.js';
 import { uiResources } from './lib/resources.js';
+import { loadTranslationsFromAPI } from './lib/loadTranslations.js';
 
 startTransition(async () => {
   try {
     // Use server-rendered language for initial hydration to prevent mismatch
     const serverLang = document.documentElement.lang || 'en';
-    const i18n = await initI18n({ lng: serverLang });
+    // Hydrate with the exact same resources used on the server to avoid mismatch
+    const i18n = await initI18n({ lng: serverLang, resources: uiResources[serverLang] || uiResources.en });
     
     hydrateRoot(document, <StrictMode><I18nextProvider i18n={i18n} key={serverLang}><HydratedRouter /></I18nextProvider></StrictMode>);
     
@@ -20,6 +22,18 @@ startTransition(async () => {
         const storedLang = localStorage.getItem('lng');
         const clientLang = urlLang || storedLang || serverLang;
         
+        // Merge server translations after hydration to enrich resources without breaking keys used by SSR
+        try {
+          const apiTranslations = await loadTranslationsFromAPI(clientLang);
+          if (apiTranslations && typeof apiTranslations === 'object') {
+            for (const [ns, nsRes] of Object.entries(apiTranslations)) {
+              i18n.addResourceBundle(clientLang, ns, nsRes, true, true);
+            }
+          }
+        } catch (e) {
+          console.warn('Failed to load/merge API translations post-hydration:', e);
+        }
+
         if (clientLang !== serverLang && i18n?.changeLanguage) {
           console.log('🌍 Client language sync:', { server: serverLang, client: clientLang });
           await i18n.changeLanguage(clientLang);

--- a/app/routes/home.jsx
+++ b/app/routes/home.jsx
@@ -698,7 +698,7 @@ function CarouselTestimonials({ testimonials }) {
                       <Star key={i} className={`size-3 ${i < Number(t.rating || 0) ? 'fill-current' : ''}`} />
                     ))}
                   </div>
-                  <div className="text-xs text-muted-foreground">{new Date(t.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}</div>
+                  <div className="text-xs text-muted-foreground">{new Date(t.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC' })}</div>
                 </div>
                 <div className="text-sm text-muted-foreground mt-1">{t.content} <Link to="/reviews" className="underline">Read more</Link></div>
               </div>
@@ -808,7 +808,7 @@ function Testimonial({ name, initials, rating, date, children }) {
                   <Star key={i} className={`size-3 ${i < Number(rating || 0) ? 'fill-current' : ''}`} />
                 ))}
               </div>
-              <div className="text-xs text-muted-foreground">{new Date(date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}</div>
+              <div className="text-xs text-muted-foreground">{new Date(date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC' })}</div>
             </div>
             <div className="text-sm text-muted-foreground mt-1">{children}</div>
           </div>


### PR DESCRIPTION
Fix hydration mismatches by aligning i18n resources, standardizing date formatting, and deferring dynamic countdown rendering.

The "Hydration failed" error was caused by inconsistencies between server and client renders. This PR addresses it by ensuring the client's i18n initializes with the same resources as the server, adding `timeZone: 'UTC'` to `toLocaleDateString` calls to prevent timezone drift, and rendering a static placeholder for the countdown component during SSR to avoid `Date.now()` mismatches.

---
<a href="https://cursor.com/background-agent?bcId=bc-cca833a2-57f9-4ce1-9744-5f5b6dbe6257">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cca833a2-57f9-4ce1-9744-5f5b6dbe6257">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

