### PR TITLE
Fix login turbo-stream decode error

### DIFF
--- a/react-router.config.js
+++ b/react-router.config.js
@@ -2,4 +2,8 @@ export default {
   // Config options...
   // Server-side render by default, to enable SPA mode set this to `false`
   ssr: true,
+  // Disable Single Fetch to fix turbo-stream decoding errors
+  future: {
+    unstable_singleFetch: false,
+  },
 };


### PR DESCRIPTION
Disable React Router v7's `unstable_singleFetch` to fix 'Unable to decode turbo-stream response' errors during login.

The "Single Fetch" feature in React Router v7 expects server responses in a turbo-stream format, but the application's server returns standard JSON. Disabling this feature ensures compatibility and resolves the login issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9ff7256-0576-4a45-9627-081a7d7e1f3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c9ff7256-0576-4a45-9627-081a7d7e1f3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

