### PR TITLE
Greeting or placeholder task

### DIFF
--- a/app/routes/auth/login.jsx
+++ b/app/routes/auth/login.jsx
@@ -646,7 +646,7 @@ export async function action({ request, context }) {
         console.log('✅ Login successful',result);
         // Commit cookies to the browser before any follow-up auth checks
         const headerList = new Headers();
-        headerList.set('Location', '/?login=1');
+        headerList.set('Location', `/?lng=${encodeURIComponent(currentLng)}&login=1`);
         try {
             const getSetCookie = response.headers.getSetCookie?.();
             if (Array.isArray(getSetCookie) && getSetCookie.length > 0) {

--- a/app/utils/auth/authUtils.js
+++ b/app/utils/auth/authUtils.js
@@ -28,9 +28,9 @@ export async function checkAuthToken( request, csrfToken )
         const data = await response.json();
         console.log( "📌 CheckAuth Token Response:", data);
         if ( !response.ok ) {
-            // Attempt a single silent refresh if access token expired
+            // Attempt a single silent refresh if access token expired or unauthorized
             const errorType = data?.error?.type || data?.type || data?.code;
-            if ( response.status === 401 && errorType === 'TOKEN_EXPIRED' ) {
+            if ( response.status === 401 && (errorType === 'TOKEN_EXPIRED' || errorType === 'UNAUTHORIZED') ) {
                 const refreshResult = await refreshAccessToken( cookies, csrfToken );
                 if ( refreshResult && refreshResult.user && !refreshResult.refreshExpired ) {
                     // Retry token check once after successful refresh

--- a/app/utils/auth/authUtils.js
+++ b/app/utils/auth/authUtils.js
@@ -186,13 +186,16 @@ export async function refreshAccessToken( cookies, csrfToken, attempt = 1 )
     // console.log("🔄 Attempting token refresh (Attempt", attempt, ")...");
 
     try {
+        const refreshFromCookie = getCookieValue(cookies || '', 'refreshToken');
         const response = await fetch( `${API_URL}/api/auth/refresh-token`, {
             method: "POST",
             credentials: "include",
             headers: {
+                "Content-Type": "application/json",
                 "x-csrf-token": csrfToken,
-                cookie: cookies
+                cookie: cookies,
             },
+            body: JSON.stringify({ refreshToken: refreshFromCookie || undefined }),
         } );
 
 


### PR DESCRIPTION
Implement silent token refresh on `TOKEN_EXPIRED` errors, correct refresh endpoint, and remove double JSON parsing in `checkAuthToken`.

The `checkAuthToken` function previously returned `TOKEN_EXPIRED` errors directly without attempting to refresh the token, leading to premature user logouts. This change introduces a mechanism to silently refresh the access token once upon receiving a `TOKEN_EXPIRED` error and retries the token check, improving user experience by maintaining session continuity. Additionally, the refresh endpoint path was corrected to match the server's expected route, and an unnecessary double JSON parsing was removed.

---
<a href="https://cursor.com/background-agent?bcId=bc-808a7645-987f-40b4-9571-97e9287a1bee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-808a7645-987f-40b4-9571-97e9287a1bee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

